### PR TITLE
Schedule recurring role downgrading

### DIFF
--- a/active-member-discord-bot/README.md
+++ b/active-member-discord-bot/README.md
@@ -13,9 +13,9 @@ If you would like to use this bot on your server, you can follow these instructi
 2. Add the bot to your server and give it access to the appropriate rooms. Also give the bot access to manage roles.
 3. Copy your bot's access token
 4. Create an environment variable named `DISCORD_API_TOKEN` with the value of your bot's access token
-5. Execute the shell command: `./gradlew active-member-discord-bot:run --args="bot-config.yml"`.
+5. Execute the shell command: `./gradlew active-member-discord-bot:run --args="bot-config.yml --dry-run=false"`.
    - replace `bot-config.yml` with the path to your server's config
-   - Alternatively, you can build the project (`./gradlew active-member-discord-bot:build`), and run the exported JAR (`java -jar active-member-discord-bot/build/libs/active-member-discord-bot-0.1-all.jar active-member-discord-bot/bot-config.yml`).
+   - Alternatively, you can build the project (`./gradlew active-member-discord-bot:build`), and run the exported JAR (`java -jar active-member-discord-bot/build/libs/active-member-discord-bot-0.1-all.jar active-member-discord-bot/bot-config.yml --dry-run=false`).
 
 ## Configuring the bot
 

--- a/active-member-discord-bot/bot-config.yml
+++ b/active-member-discord-bot/bot-config.yml
@@ -22,8 +22,7 @@ roleConfigs:
       minPostDays: 1
     welcomeMessageConfig:
       channel: 1162017937796911209
-      prefix: "A warm hello to our newest guest, "
-      suffix: " :relaxed: Please check out <#1240458302530519123> when you have a moment."
+      template: "A warm hello to our newest guest, USER_MENTION :relaxed: Please check out <#1240458302530519123> when you have a moment."
   # Active Member
   - roleId: 1223026651340996698
     addRoleConfig:
@@ -34,5 +33,12 @@ roleConfigs:
       minPostDays: 1
     welcomeMessageConfig:
       channel: 1223262623194153111
-      prefix: "Welcome to our community, "
-      suffix: "!"
+      template: "Welcome to our community, USER_MENTION!"
+
+downgradeMessageConfig:
+  channel: 1230667079213125702
+  template: "USERNAME has transitioned from PREVIOUS_ROLE to CURRENT_ROLE."
+
+removalMessageConfig:
+  channel: 1230667079213125702
+  template: "USERNAME has been removed from PREVIOUS_ROLE and no longer has an active role."

--- a/active-member-discord-bot/build.gradle.kts
+++ b/active-member-discord-bot/build.gradle.kts
@@ -13,5 +13,7 @@ dependencies {
     implementation("dev.kord:kord-rest:${BuildConstants.DependencyVersions.kord}")
     implementation("dev.kord:kord-gateway:${BuildConstants.DependencyVersions.kord}")
 
+    implementation("com.github.ajalt.clikt:clikt:${BuildConstants.DependencyVersions.clikt}")
+
     testImplementation("org.junit.jupiter:junit-jupiter-params:${BuildConstants.TestDependencyVersions.junit}")
 }

--- a/active-member-discord-bot/build.gradle.kts
+++ b/active-member-discord-bot/build.gradle.kts
@@ -7,6 +7,8 @@ plugins {
 dependencies {
     implementation(project(":json-lib"))
 
+    runtimeOnly("org.jetbrains.kotlinx:kotlinx-coroutines-core:${BuildConstants.DependencyVersions.kotlinCoroutinesCore}")
+
     implementation("dev.kord:kord-core:${BuildConstants.DependencyVersions.kord}")
     implementation("dev.kord:kord-rest:${BuildConstants.DependencyVersions.kord}")
     implementation("dev.kord:kord-gateway:${BuildConstants.DependencyVersions.kord}")

--- a/active-member-discord-bot/src/main/kotlin/regenerativeag/ActiveMemberDiscordBot.kt
+++ b/active-member-discord-bot/src/main/kotlin/regenerativeag/ActiveMemberDiscordBot.kt
@@ -17,7 +17,6 @@ class ActiveMemberDiscordBot(
 ) {
     private val logger = KotlinLogging.logger {  }
     private val lock = object { }
-    private val roleNameByRoleId = discord.server.fetchAllRoles(activeMemberConfig.serverId)
 
     fun login() {
         Reloader().cleanReload()
@@ -42,7 +41,8 @@ class ActiveMemberDiscordBot(
             for (roleConfig in activeMemberConfig.roleConfigs.reversed()) {
                 val meetsThreshold = meetsThreshold(roleConfig, postDays, LocalDate.now())
                 if (meetsThreshold) {
-                    logger.debug { "(Re)adding ${roleNameByRoleId[roleConfig.roleId]} for \"${message.userId}\"." }
+                    val roleName = discord.roleNameCache.lookup(activeMemberConfig.serverId, roleConfig.roleId)
+                    logger.debug { "(Re)adding $roleName for \"${message.userId}\"." }
                     discord.users.addActiveRole(activeMemberConfig, roleConfig, setOf(message.userId))
                     break
                 }
@@ -126,18 +126,18 @@ class ActiveMemberDiscordBot(
 
         /** Ensure that the role identified by [roleConfig] includes exactly the members in [computedMemberIds] */
         private fun updateRoleMembers(computedMemberIds: Set<UserId>, roleConfig: ActiveMemberConfig.RoleConfig) {
-            val roleName = roleNameByRoleId[roleConfig.roleId]
-            fun print(prefix: String, userIds: Set<UserId>) {
+            val roleName = discord.roleNameCache.lookup(activeMemberConfig.serverId, roleConfig.roleId)
+            fun log(prefix: String, userIds: Set<UserId>) {
                 logger.debug { "$prefix $roleName (${userIds.size}): ${discord.users.mapUserIdsToNames(userIds).sorted()}" }
             }
 
-            print("Computed members in", computedMemberIds)
+            log("Computed members in", computedMemberIds)
 
             val currentMemberIds = discord.users.getUsersWithRole(activeMemberConfig.serverId, roleConfig.roleId)
-            print("Current members in", currentMemberIds)
+            log("Current members in", currentMemberIds)
 
             val userIdsToAdd = computedMemberIds - currentMemberIds
-            print("New members to add to", userIdsToAdd)
+            log("New members to add to", userIdsToAdd)
             val retainedUserIdsToAdd = discord.users.filterToUsersCurrentlyInGuild(
                 activeMemberConfig.serverId,
                 userIdsToAdd

--- a/active-member-discord-bot/src/main/kotlin/regenerativeag/ActiveMemberDiscordBot.kt
+++ b/active-member-discord-bot/src/main/kotlin/regenerativeag/ActiveMemberDiscordBot.kt
@@ -144,7 +144,7 @@ class ActiveMemberDiscordBot(
             )
             val usersWhoLeftButMetThreshold = userIdsToAdd - retainedUserIdsToAdd
             departedUserIds.addAll(usersWhoLeftButMetThreshold)
-            discord.users.addActiveRole(activeMemberConfig, roleConfig, userIdsToAdd)
+            discord.users.addActiveRole(activeMemberConfig, roleConfig, retainedUserIdsToAdd)
 
             memberIdsWhoHadARoleBeforeRunning.addAll(currentMemberIds)
             memberIdsWhoHaveARoleAfterRunning.addAll(computedMemberIds)

--- a/active-member-discord-bot/src/main/kotlin/regenerativeag/Database.kt
+++ b/active-member-discord-bot/src/main/kotlin/regenerativeag/Database.kt
@@ -31,7 +31,11 @@ class Database() {
         }
     }
 
-    fun getPostHistory() = postHistory.toMap()
+    fun getPostHistory(): Map<UserId, Set<LocalDate>> {
+        synchronized(lock) {
+            return postHistory.toMap()
+        }
+    }
 
     companion object {
         data class AddPostResult(val isFirstPostOfDay: Boolean, val postDays: Set<LocalDate>)

--- a/active-member-discord-bot/src/main/kotlin/regenerativeag/Database.kt
+++ b/active-member-discord-bot/src/main/kotlin/regenerativeag/Database.kt
@@ -31,6 +31,8 @@ class Database() {
         }
     }
 
+    fun getPostHistory() = postHistory.toMap()
+
     companion object {
         data class AddPostResult(val isFirstPostOfDay: Boolean, val postDays: Set<LocalDate>)
     }

--- a/active-member-discord-bot/src/main/kotlin/regenerativeag/Main.kt
+++ b/active-member-discord-bot/src/main/kotlin/regenerativeag/Main.kt
@@ -1,5 +1,13 @@
 package regenerativeag
 
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.arguments.help
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.help
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.required
+import com.github.ajalt.clikt.parameters.types.boolean
 import io.ktor.client.*
 import io.ktor.client.plugins.*
 import mu.KotlinLogging
@@ -7,34 +15,38 @@ import regenerativeag.model.ActiveMemberConfig
 import regenerativeag.tools.GlobalObjectMapper
 import java.io.File
 
-private val logger = KotlinLogging.logger { }
 
-fun main(args: Array<String>) {
-    val token = System.getenv("DISCORD_API_TOKEN")
-    if (token.isNullOrEmpty()) {
-        println("Please set the DISCORD_API_TOKEN env var")
-    } else if (args.size != 1) {
-        println("Please provide the path to the configuration file as a single command line argument")
-    } else {
-        val configPath = args[0]
-        logger.debug { "Config path: $configPath" }
-        run(token, configPath)
+class Main : CliktCommand() {
+    private val logger = KotlinLogging.logger { }
+
+    val configPath: String by argument()
+        .help("path to the configuration file")
+
+    val dryRun: Boolean by option()
+        .boolean()
+        .default(true)
+        .help("set to false in order for changes to take effect")
+
+    val discordApiToken: String by option(envvar="DISCORD_API_TOKEN")
+        .required()
+
+    override fun run() {
+        logger.info("Launching with configPath=$configPath, dryRun=$dryRun, discordApiToken=<omitted>")
+        val httpClient = createHttpClient()
+        val discord = Discord(httpClient, discordApiToken, dryRun)
+        val database = Database()
+        val config = GlobalObjectMapper.readValue(File(configPath), ActiveMemberConfig::class.java)
+        val bot = ActiveMemberDiscordBot(database, discord, config)
+        bot.login()
+    }
+
+    private fun createHttpClient() = HttpClient {
+        expectSuccess = false
+        install(HttpRequestRetry) {
+            retryOnServerErrors(3)
+            exponentialDelay()
+        }
     }
 }
 
-private fun run(discordApiToken: String, configPath: String) {
-    val httpClient = createHttpClient()
-    val discord = Discord(httpClient, discordApiToken)
-    val database = Database()
-    val config = GlobalObjectMapper.readValue(File(configPath), ActiveMemberConfig::class.java)
-    val bot = ActiveMemberDiscordBot(database, discord, config)
-    bot.login()
-}
-
-private fun createHttpClient() = HttpClient {
-    expectSuccess = false
-    install(HttpRequestRetry) {
-        retryOnServerErrors(3)
-        exponentialDelay()
-    }
-}
+fun main(args: Array<String>) = Main().main(args)

--- a/active-member-discord-bot/src/main/kotlin/regenerativeag/discord/RoleNameCache.kt
+++ b/active-member-discord-bot/src/main/kotlin/regenerativeag/discord/RoleNameCache.kt
@@ -1,0 +1,29 @@
+package regenerativeag.discord
+
+import dev.kord.common.entity.Snowflake
+import dev.kord.rest.service.RestClient
+import kotlinx.coroutines.runBlocking
+import regenerativeag.model.RoleId
+import regenerativeag.model.ServerId
+
+class RoleNameCache(
+    private val restClient: RestClient,
+) {
+    private val cache = mutableMapOf<RoleId, String>()
+    private val seenServerIds = mutableSetOf<ServerId>()
+
+    fun lookup(serverId: ServerId, roleId: RoleId): String {
+        return synchronized(cache) {
+            if (serverId !in seenServerIds) {
+                val roleNameByRoleId = runBlocking {
+                    restClient.guild.getGuildRoles(Snowflake(serverId)).associate {
+                        it.id.value to it.name
+                    }
+                }
+                cache.putAll(roleNameByRoleId)
+                seenServerIds.add(serverId)
+            }
+            cache[roleId]!!
+        }
+    }
+}

--- a/active-member-discord-bot/src/main/kotlin/regenerativeag/model/ActiveMemberConfig.kt
+++ b/active-member-discord-bot/src/main/kotlin/regenerativeag/model/ActiveMemberConfig.kt
@@ -1,22 +1,60 @@
 package regenerativeag.model
 
 data class ActiveMemberConfig(
-        val serverId: ServerId, // aka "guild id"
-        val excludedUserIds: Set<UserId>, // bots
-        val roleConfigs: List<RoleConfig>,
+    val serverId: ServerId, // aka "guild id"
+    val excludedUserIds: Set<UserId>, // bots
+    val roleConfigs: List<RoleConfig>,
+    val downgradeMessageConfig: DowngradeMessageConfig,
+    val removalMessageConfig: RemovalMessageConfig,
 ) {
     val maxWindowSize: Int = roleConfigs.flatMap {
             listOf(it.keepRoleConfig.windowSize, it.addRoleConfig.windowSize)
     }.max()
-        data class RoleConfig(
-                val roleId: RoleId,
-                val addRoleConfig: AddRoleConfig,
-                val keepRoleConfig: KeepRoleConfig,
-                val welcomeMessageConfig: WelcomeMessageConfig,
-        )
-        data class WelcomeMessageConfig(
-                val channel: ChannelId,
-                val prefix: String,
-                val suffix: String,
-        )
+
+    data class RoleConfig(
+        val roleId: RoleId,
+        val addRoleConfig: AddRoleConfig,
+        val keepRoleConfig: KeepRoleConfig,
+        val welcomeMessageConfig: WelcomeMessageConfig,
+    )
+
+    data class WelcomeMessageConfig(
+        val channel: ChannelId,
+        val template: String,
+        val userMentionPlaceholder: String = "USER_MENTION",
+    ) {
+        fun createWelcomeMessage(userId: UserId): String {
+            return template
+                .replace(userMentionPlaceholder, "<@$userId>")
+        }
+    }
+
+
+    data class DowngradeMessageConfig(
+        val channel: ChannelId,
+        val template: String,
+        val usernamePlaceholder: String = "USERNAME",
+        val previousRolePlaceholder: String = "PREVIOUS_ROLE",
+        val currentRolePlaceholder: String = "CURRENT_ROLE",
+    ) {
+        fun createDowngradeMessage(username: String, previousRoleName: String, currentRoleName: String): String {
+            return template
+                .replace(usernamePlaceholder, username)
+                .replace(previousRolePlaceholder, previousRoleName)
+                .replace(currentRolePlaceholder, currentRoleName)
+        }
+    }
+
+    data class RemovalMessageConfig(
+        val channel: ChannelId,
+        val template: String,
+        val usernamePlaceholder: String = "USERNAME",
+        val previousRolePlaceholder: String = "PREVIOUS_ROLE"
+    ) {
+        fun createRemovalMessage(username: String, previousRoleName: String): String {
+            return template
+                .replace(usernamePlaceholder, username)
+                .replace(previousRolePlaceholder, previousRoleName)
+        }
+    }
 }

--- a/active-member-discord-bot/src/test/kotlin/regenerativeag/ActiveMemberDiscordBotTest.kt
+++ b/active-member-discord-bot/src/test/kotlin/regenerativeag/ActiveMemberDiscordBotTest.kt
@@ -51,7 +51,9 @@ class ActiveMemberDiscordBotTest {
                                 "end"
                             )
                         )
-                    )
+                    ),
+                    ActiveMemberConfig.DowngradeMessageConfig(0uL, "template"),
+                    ActiveMemberConfig.RemovalMessageConfig(0uL, "template",)
             )
     ) {
         EMPTY(),

--- a/buildSrc/src/main/kotlin/regenerativeag/BuildConstants.kt
+++ b/buildSrc/src/main/kotlin/regenerativeag/BuildConstants.kt
@@ -11,6 +11,7 @@ object BuildConstants {
         val kotlinCoroutinesCore = "1.8.0"
         val kord = "0.13.1"
         val jackson = "2.17.1"
+        val clikt = "4.4.0"
     }
 
     object TestDependencyVersions {


### PR DESCRIPTION
TODO
- [x]  Run downgrade code once per day
- [x]  Post message to staff-only channel so we are aware of downgrades.

Blocked:
- [ ] Add a 3-day grace period for the active member role
    - if someone posts within 3 days of losing their membership, they automatically regain without having to go through the full rules to re-acquire...
    - they also should get a different message in the room if they are being re-added during a grace period vs joining for the first time (or rejoining many weeks/months after they last had the role)
    - blocked on: https://github.com/regenerativeag/tools/issues/2